### PR TITLE
link refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ instead.
   of ferret images, in use with ferret_api
 - [gdt (2)](https://github.com/LeoDog896/gdt) - gdscript tools for abstract
   manipulation of ASTs
+- [jsnow (2)](https://github.com/LeoDog896/jsnow)
+  ([homepage](https://now.js.org)) - no clutter. just js, now.
 - [kanban (2)](https://github.com/LeoDog896/kanban) - a kanban management system
 - [lichess-minecraft (2)](https://github.com/LeoDog896/lichess-minecraft) -
   lichess board implementation for minecraft.
@@ -84,8 +86,6 @@ instead.
   in godot
 - [jigsawable (1)](https://github.com/LeoDog896/jigsawable) - jigsaw game in
   godot, demonstrating the `godot-jigsaw` repository example
-- [jsnow (1)](https://github.com/LeoDog896/jsnow)
-  ([homepage](https://now.js.org)) - no clutter. just js, now.
 - [Logitech-Extreme-3d-Pro-Visualizer (1)](https://github.com/LeoDog896/Logitech-Extreme-3d-Pro-Visualizer)
   ([homepage](https://leodog896.github.io/Logitech-Extreme-3d-Pro-Visualizer/)) -
   Check out the data sent by your logitech controller!

--- a/grab.ts
+++ b/grab.ts
@@ -13,7 +13,8 @@ type Repo = z.infer<typeof repoSchema>;
 
 console.log("Fetching repos...");
 async function* getRepos(): AsyncGenerator<Repo, void, void> {
-  let url: string | undefined = "https://api.github.com/users/LeoDog896/repos?per_page=100";
+  let url: string | undefined =
+    "https://api.github.com/user/26509014/repos?per_page=100";
 
   while (url) {
     console.log("Querying", url);
@@ -26,6 +27,13 @@ async function* getRepos(): AsyncGenerator<Repo, void, void> {
         },
       },
     );
+
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch ${url}: ${res.status} ${res.statusText}`,
+      );
+    }
+
     const data = await res.json();
 
     const next = res.headers.get("Link")?.match(/<([^>]+)>; rel="next"/);

--- a/grab.ts
+++ b/grab.ts
@@ -13,10 +13,13 @@ type Repo = z.infer<typeof repoSchema>;
 
 console.log("Fetching repos...");
 async function* getRepos(): AsyncGenerator<Repo, void, void> {
-  let page = 1;
-  while (true) {
+  let url: string | undefined = "https://api.github.com/users/LeoDog896/repos?per_page=100";
+
+  while (url) {
+    console.log("Querying", url);
+
     const res = await fetch(
-      `https://api.github.com/users/LeoDog896/repos?page=${page}&per_page=100`,
+      url,
       {
         headers: {
           "X-GitHub-Api-Version": "2022-11-28",
@@ -24,13 +27,13 @@ async function* getRepos(): AsyncGenerator<Repo, void, void> {
       },
     );
     const data = await res.json();
-    if (data.length === 0) {
-      break;
-    }
+
+    const next = res.headers.get("Link")?.match(/<([^>]+)>; rel="next"/);
+    url = next?.[1];
+
     for (const repo of data) {
       yield repoSchema.parse(repo);
     }
-    page++;
   }
 }
 


### PR DESCRIPTION
by following the Link header instead of incrementing the page, we can avoid an unnecessary `while(true)` or even a `do {} while`.